### PR TITLE
Update the GitHub token variable name

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -62,7 +62,7 @@ jobs:
       - name: Create tag
         uses: actions/github-script@v7
         with:
-          github-token: ${{ secrets.TAG_CREATION_TOKEN }}
+          github-token: ${{ secrets.VEMPAIN_ACTION_TOKEN }}
           script: |
             github.rest.git.createRef({
               owner: context.repo.owner,


### PR DESCRIPTION
This pull request updates the token used for tag creation in the CI workflow. The change improves security or aligns with updated secrets management practices.

* CI workflow: Changed the token for GitHub tag creation from `${{ secrets.TAG_CREATION_TOKEN }}` to `${{ secrets.VEMPAIN_ACTION_TOKEN }}` in `.github/workflows/ci.yaml`.